### PR TITLE
Add support for tls in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,8 @@ The following command will connect the the server located at `tcprouter-1.com`, 
 
 
 `trc -local localhost:8080 -remote tcprouter-1.com -secret TB2pbZ5FR8GQZp9W2z97jBjxSgWgQKaQTxEgrZNBa4pEFzv3PJcRVEtG2a5BU9qd`
+
+
+To forward tls traffic to a difference port than none-tls traffic add the `--local-tls` flag
+
+`trc -local localhost:8080 -local-tls localhost:443 -remote tcprouter-1.com -secret TB2pbZ5FR8GQZp9W2z97jBjxSgWgQKaQTxEgrZNBa4pEFzv3PJcRVEtG2a5BU9qd`

--- a/cmds/client/main.go
+++ b/cmds/client/main.go
@@ -36,6 +36,11 @@ func main() {
 			Usage:   "address to the local application",
 			EnvVars: []string{"TRC_LOCAL"},
 		},
+		&cli.StringFlag{
+			Name:    "local-tls",
+			Usage:   "address to the local tls application",
+			EnvVars: []string{"TRC_LOCAL"},
+		},
 		&cli.IntFlag{
 			Name:    "backoff",
 			Value:   5,
@@ -47,6 +52,10 @@ func main() {
 	app.Action = func(c *cli.Context) error {
 		remotes := c.StringSlice("remote")
 		local := c.String("local")
+		localtls := c.String("local-tls")
+		if len(localtls) == 0 {
+			localtls = local
+		}
 		backoff := c.Int("backoff")
 		secret := c.String("secret")
 
@@ -60,10 +69,11 @@ func main() {
 
 		for _, remote := range remotes {
 			c := connection{
-				Secret:  secret,
-				Remote:  remote,
-				Local:   local,
-				Backoff: backoff,
+				Secret:   secret,
+				Remote:   remote,
+				Local:    local,
+				LocalTLS: localtls,
+				Backoff:  backoff,
 			}
 			go func() {
 				defer func() {
@@ -89,14 +99,15 @@ func main() {
 }
 
 type connection struct {
-	Secret  string
-	Remote  string
-	Local   string
-	Backoff int
+	Secret   string
+	Remote   string
+	Local    string
+	LocalTLS string
+	Backoff  int
 }
 
 func start(ctx context.Context, c connection) {
-	client := tcprouter.NewClient(c.Secret, c.Local, c.Remote)
+	client := tcprouter.NewClient(c.Secret, c.Local, c.LocalTLS, c.Remote)
 
 	op := func() error {
 		for {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -74,7 +74,7 @@ func testEnd2End(t *testing.T, size int) {
 		local := u.Host
 		remote := fmt.Sprintf("%s:%d", domain, clientPort)
 		log.Printf("start client local:%v remote:%v\n", local, remote)
-		client := NewClient(secret, local, remote)
+		client := NewClient(secret, local, local, remote)
 		client.Start(ctx)
 	}()
 


### PR DESCRIPTION
When local-tls is passed we forward tls traffic to another port than
none tls traffic if local-tls is ommited all traffic goes to local

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>